### PR TITLE
Also activate in cjs and cts

### DIFF
--- a/lsp-biome.el
+++ b/lsp-biome.el
@@ -36,7 +36,12 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/cxa/lsp-biome"))
 
-(defcustom lsp-biome-active-file-types '("\\.[tj]s[x]?\\'" "\\.json[c]?\\'")
+(defcustom lsp-biome-active-file-types (list (rx "." (or "tsx" "jsx"
+                                                         "ts" "js"
+                                                         "mts" "mjs"
+                                                         "cts" "cjs"
+                                                         "json" "jsonc")
+                                                 eos))
   "File types that lsp-biome should activate."
   :type '(repeat regexp)
   :group 'lsp-biome)


### PR DESCRIPTION
Currently lsp-biome does not activate in, for example, [.cjs or .mjs files](https://nodejs.org/api/packages.html#introduction_1). This PR fixes that, enabling lsp-biome in cjs, cts, mjs, and mts files.

This also rewrites the file type regexp to use `rx`, which makes the intent more readable and produces a more efficient regexp.

rx is already used extensively in lsp-mode.el, so it's not a new dependency.