### PR TITLE
Allow finding biome executable at exec-path (aka OS PATH).

### DIFF
--- a/lsp-biome.el
+++ b/lsp-biome.el
@@ -100,7 +100,7 @@ We look for the executable first the npm installation of `biome', then the OS PA
               (bin (lsp-biome--find-exe
                     (let
                         ((broot (locate-dominating-file wroot node-biome-bin)))
-                      (if broot (cons broot exec-path) exec-path))))
+                      (if broot (cons (concat broot node-biome-bin) exec-path) exec-path))))
               ((lsp-biome--has-config-p))
               ((lsp-biome--file-can-be-activated filename)))
     (setq-local lsp-biome--bin-path bin)

--- a/lsp-biome.el
+++ b/lsp-biome.el
@@ -29,6 +29,7 @@
 
 ;;; Code:
 
+(require 'cl-seq)
 (require 'lsp-mode)
 
 (defgroup lsp-biome nil
@@ -99,7 +100,7 @@ We look for the executable first the npm installation of `biome', then the OS PA
               (bin (lsp-biome--find-exe
                     (let
                         ((broot (locate-dominating-file wroot node-biome-bin)))
-                      (if broot (cons node-biome-bin exec-path) exec-path))))
+                      (if broot (cons broot exec-path) exec-path))))
               ((lsp-biome--has-config-p))
               ((lsp-biome--file-can-be-activated filename)))
     (setq-local lsp-biome--bin-path bin)


### PR DESCRIPTION
* Add a function to find an executable in a list of dirs. Can be generally useful.
* Replace broot and bin in lsp-biome--activate-p with that. The npm-installed version takes priority over PATH.
* Alter the relevant doc string.