### PR TITLE
fix: Emacs 29 File mode specification error: project-try-vc--search

### DIFF
--- a/lsp-biome.el
+++ b/lsp-biome.el
@@ -71,12 +71,12 @@
                       (lsp-workspace-root file-name)
                       ;; 2. root by `project.el`
                       ;; 2.1 find root in normal way
-                      (when-let ((proj (project-try-vc--search dir)))
+                      (when-let ((proj (project-try-vc dir)))
                         (project-root proj))
                       ;; 2.2  `project-vc-extra-root-markers' is nil,
                       ;;      ensures that we can retrieve the topmost root
                       (let ((project-vc-extra-root-markers nil))
-                        (when-let ((proj (project-try-vc--search dir)))
+                        (when-let ((proj (project-try-vc dir)))
                           (project-root proj)))
                       ;; 3. root by locating `biome.jsonc?`
                       (or (locate-dominating-file dir "biome.json")


### PR DESCRIPTION
Fix Emacs 29 compatibility issue with void-function error

## Problem

  lsp-biome fails to start in Emacs 29 with the error:
  File mode specification error: (void-function project-try-vc--search)

## Root Cause

  The code calls project-try-vc--search (lines 74, 79), which is an internal implementation function (indicated by the -- suffix).
